### PR TITLE
Replace assertEquals with assertEqual in tests/test_module.py

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -102,7 +102,7 @@ class TestModule(unittest.TestCase):
         result = python_module.function_variables("Cls", "func")
         expected = ["function_variable"]
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_module_filter_below_false(self):
         python_string = textwrap.dedent("""


### PR DESCRIPTION
Running py.test throws a DeprecationWarning w/r/t assertEquals

```
(gsoc_env) ➜  cohesion git:(master) py.test
============================================= test session starts ==============================================
platform linux -- Python 3.7.4, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /home/jaskaran/packages/cohesion
collected 62 items                                                                                             

tests/test_filesystem.py ...                                                                             [  4%]
tests/test_flake8_extension.py .....                                                                     [ 12%]
tests/test_module.py ................                                                                    [ 38%]
tests/test_parser.py ......................................                                              [100%]

=============================================== warnings summary ===============================================
tests/test_module.py::TestModule::test_module_function_variable
  /home/jaskaran/packages/cohesion/tests/test_module.py:105: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(result, expected)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================== 62 passed, 1 warnings in 0.12 seconds =====================================
```

Replacing assertEquals with assertEqual in tests/test_module.py passes tests without the warning above.